### PR TITLE
Show how to use io.opentracing.Scheduler

### DIFF
--- a/opentracing-api/pom.xml
+++ b/opentracing-api/pom.xml
@@ -40,5 +40,20 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.23</version>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.23</version>
+        </dependency>
     </dependencies>
 </project>

--- a/opentracing-mdc-demo/pom.xml
+++ b/opentracing-mdc-demo/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2017 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.opentracing</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.20.8-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>opentracing-mdc-demo</artifactId>
+    <name>OpenTracing-mdc-demo</name>
+    <description>OpenTracing MDC Demo</description>
+
+    <properties>
+        <main.basedir>${project.basedir}/..</main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>opentracing-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>opentracing-mock</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/opentracing-mdc-demo/pom.xml
+++ b/opentracing-mdc-demo/pom.xml
@@ -40,6 +40,21 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>opentracing-mock</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.23</version>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.23</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/opentracing-mdc-demo/pom.xml
+++ b/opentracing-mdc-demo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.opentracing</groupId>
         <artifactId>parent</artifactId>
-        <version>0.20.8-SNAPSHOT</version>
+        <version>0.20.11-SNAPSHOT</version>
     </parent>
 
     <artifactId>opentracing-mdc-demo</artifactId>

--- a/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/MDCDemo.java
+++ b/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/MDCDemo.java
@@ -1,0 +1,120 @@
+package io.opentracing.mdcdemo;
+
+import io.opentracing.Span;
+import io.opentracing.SpanScheduler;
+import io.opentracing.Tracer;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import org.slf4j.Logger;
+import org.slf4j.MDC;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+public class MDCDemo {
+    Tracer tracer;
+
+    private MDCDemo(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    public void trivialSpan() {
+        Span span = this.tracer.buildSpan("trivial").start();
+        span.finish();
+    }
+
+    public void trivialChild() {
+        Span parent = this.tracer.buildSpan("trivialParent").start();
+        // The child will automatically know about the parent.
+        Span child = this.tracer.buildSpan("trivialChild").start();
+        child.finish();
+        parent.finish();
+    }
+
+    public void asyncSpans() {
+        final Tracer tracer = this.tracer; // save typing
+
+        // Create an ExecutorService and wrap it in a TracedExecutorService.
+        ExecutorService realExecutor = Executors.newFixedThreadPool(500);
+        final ExecutorService otExecutor = new TracedExecutorService(realExecutor, tracer.spanScheduler());
+
+        // Hacky lists of futures we wait for before exiting async Spans.
+        final List<Future<?>> futures = new ArrayList<>();
+        final List<Future<?>> subfutures = new ArrayList<>();
+
+        // Create a parent Continuation for all of the async activity.
+        try (final SpanScheduler.Continuation parentContinuation = tracer.buildSpan("parent").startAndActivate(true);) {
+
+            // Create 10 async children.
+            for (int i = 0; i < 10; i++) {
+                final int j = i;
+                futures.add(otExecutor.submit(new Runnable() {
+                    @Override
+                    public void run() {
+                        // START child body
+
+                        try (final SpanScheduler.Continuation childContinuation =
+                                     tracer.buildSpan("child_" + j).startAndActivate(false);) {
+                            Thread.currentThread().sleep(1000);
+                            tracer.spanScheduler().active().log("awoke");
+                            Runnable r = new Runnable() {
+                                @Override
+                                public void run() {
+                                    Span active = tracer.spanScheduler().active();
+                                    active.log("awoke again");
+                                    // Create a grandchild for each child.
+                                    Span grandchild = tracer.buildSpan("grandchild_" + j).start();
+                                    grandchild.finish();
+                                    active.finish();
+                                }
+                            };
+                            subfutures.add(otExecutor.submit(r));
+                        } catch (Exception e) { }
+
+                        // END child body
+                    }
+                }));
+            }
+        } catch (Exception e) { }
+
+        try {
+            for (Future<?> f : futures) {
+                f.get();
+            }
+            for (Future<?> f : subfutures) {
+                f.get();
+            }
+        } catch (Exception e) { }
+
+        otExecutor.shutdown();
+        try {
+            otExecutor.awaitTermination(3, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void main(String[] args) {
+        org.apache.log4j.BasicConfigurator.configure();
+        final Logger logger = org.slf4j.LoggerFactory.getLogger("hack");
+        MDC.put("mdcKey", "mdcVal");
+
+        final MockTracer tracer = new MockTracer(new MDCSpanScheduler());
+
+        // Do stuff with the MockTracer.
+        {
+            MDCDemo demo = new MDCDemo(tracer);
+            demo.trivialSpan();
+            demo.trivialChild();
+            demo.asyncSpans();
+        }
+
+        // Print out all mock-Spans
+        List<MockSpan> finishedSpans = tracer.finishedSpans();
+        for (MockSpan span : finishedSpans) {
+            logger.info("finished Span '{}'. trace={}, span={}, parent={}", span.operationName(), span.context().traceId(), span.context().spanId(), span.parentId());
+        }
+
+    }
+}

--- a/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/MDCDemo.java
+++ b/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/MDCDemo.java
@@ -32,7 +32,7 @@ public class MDCDemo {
         parent.finish();
     }
 
-    public void asyncSpans() {
+    public void asyncSpans() throws Exception {
         final Tracer tracer = this.tracer; // save typing
 
         // Create an ExecutorService and wrap it in a TracedExecutorService.
@@ -76,26 +76,19 @@ public class MDCDemo {
                     }
                 }));
             }
-        } catch (Exception e) { }
-
-        try {
             for (Future<?> f : futures) {
                 f.get();
             }
             for (Future<?> f : subfutures) {
                 f.get();
             }
-        } catch (Exception e) { }
+        }
 
         otExecutor.shutdown();
-        try {
-            otExecutor.awaitTermination(3, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+        otExecutor.awaitTermination(3, TimeUnit.SECONDS);
     }
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         org.apache.log4j.BasicConfigurator.configure();
         final Logger logger = org.slf4j.LoggerFactory.getLogger("hack");
         MDC.put("mdcKey", "mdcVal");

--- a/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/MDCDemo.java
+++ b/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/MDCDemo.java
@@ -37,7 +37,7 @@ public class MDCDemo {
 
         // Create an ExecutorService and wrap it in a TracedExecutorService.
         ExecutorService realExecutor = Executors.newFixedThreadPool(500);
-        final ExecutorService otExecutor = new TracedExecutorService(realExecutor, tracer.spanScheduler());
+        final ExecutorService otExecutor = new TracedExecutorService(realExecutor, tracer.scheduler());
 
         // Hacky lists of futures we wait for before exiting async Spans.
         final List<Future<?>> futures = new ArrayList<>();
@@ -57,11 +57,11 @@ public class MDCDemo {
                         try (final SpanScheduler.Continuation childContinuation =
                                      tracer.buildSpan("child_" + j).startAndActivate(false);) {
                             Thread.currentThread().sleep(1000);
-                            tracer.spanScheduler().active().log("awoke");
+                            tracer.scheduler().active().log("awoke");
                             Runnable r = new Runnable() {
                                 @Override
                                 public void run() {
-                                    Span active = tracer.spanScheduler().active();
+                                    Span active = tracer.scheduler().active();
                                     active.log("awoke again");
                                     // Create a grandchild for each child.
                                     Span grandchild = tracer.buildSpan("grandchild_" + j).start();

--- a/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/MDCDemo.java
+++ b/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/MDCDemo.java
@@ -1,7 +1,7 @@
 package io.opentracing.mdcdemo;
 
+import io.opentracing.Scheduler;
 import io.opentracing.Span;
-import io.opentracing.SpanScheduler;
 import io.opentracing.Tracer;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
@@ -44,7 +44,7 @@ public class MDCDemo {
         final List<Future<?>> subfutures = new ArrayList<>();
 
         // Create a parent Continuation for all of the async activity.
-        try (final SpanScheduler.Continuation parentContinuation = tracer.buildSpan("parent").startAndActivate(true);) {
+        try (final Scheduler.Continuation parentContinuation = tracer.buildSpan("parent").startAndActivate(true);) {
 
             // Create 10 async children.
             for (int i = 0; i < 10; i++) {
@@ -54,7 +54,7 @@ public class MDCDemo {
                     public void run() {
                         // START child body
 
-                        try (final SpanScheduler.Continuation childContinuation =
+                        try (final Scheduler.Continuation childContinuation =
                                      tracer.buildSpan("child_" + j).startAndActivate(false);) {
                             Thread.currentThread().sleep(1000);
                             tracer.scheduler().active().log("awoke");
@@ -93,7 +93,7 @@ public class MDCDemo {
         final Logger logger = org.slf4j.LoggerFactory.getLogger("hack");
         MDC.put("mdcKey", "mdcVal");
 
-        final MockTracer tracer = new MockTracer(new MDCSpanScheduler());
+        final MockTracer tracer = new MockTracer(new MDCScheduler());
 
         // Do stuff with the MockTracer.
         {

--- a/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/MDCDemo.java
+++ b/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/MDCDemo.java
@@ -24,12 +24,12 @@ public class MDCDemo {
         span.finish();
     }
 
-    public void trivialChild() {
-        Span parent = this.tracer.buildSpan("trivialParent").start();
-        // The child will automatically know about the parent.
-        Span child = this.tracer.buildSpan("trivialChild").start();
-        child.finish();
-        parent.finish();
+    public void trivialChild() throws Exception {
+        try (Scheduler.Continuation c = this.tracer.buildSpan("trivialParent").startAndActivate(true)) {
+            // The child will automatically know about the parent.
+            Span child = this.tracer.buildSpan("trivialChild").start();
+            child.finish();
+        }
     }
 
     public void asyncSpans() throws Exception {

--- a/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/MDCScheduler.java
+++ b/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/MDCScheduler.java
@@ -2,16 +2,16 @@ package io.opentracing.mdcdemo;
 
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
-import io.opentracing.SpanScheduler;
+import io.opentracing.Scheduler;
 import org.slf4j.MDC;
 
 import java.util.Map;
 
 /**
- * MDCSpanScheduler illustrates the core SpanScheduler concepts and capabilities to a first approximation. Not
+ * MDCScheduler illustrates the core Scheduler concepts and capabilities to a first approximation. Not
  * production-quality code.
  */
-public class MDCSpanScheduler implements SpanScheduler {
+public class MDCScheduler implements Scheduler {
     private final ThreadLocal<MDCSnapshot> tlsSnapshot = new ThreadLocal<MDCSnapshot>();
 
     class MDCSnapshot implements Continuation {

--- a/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/MDCScheduler.java
+++ b/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/MDCScheduler.java
@@ -12,6 +12,7 @@ import java.util.Map;
  * production-quality code.
  */
 public class MDCScheduler implements Scheduler {
+<<<<<<< Updated upstream
     private final ThreadLocal<MDCSnapshot> tlsSnapshot = new ThreadLocal<MDCSnapshot>();
 
     class MDCSnapshot implements Continuation {
@@ -21,6 +22,17 @@ public class MDCScheduler implements Scheduler {
         private MDCSnapshot toRestore = null;
 
         MDCSnapshot(Span span) {
+=======
+    private final ThreadLocal<MDCContinuation> tlsSnapshot = new ThreadLocal<MDCContinuation>();
+
+    class MDCContinuation implements Continuation {
+        private final Map<String, String> mdcContext;
+        private final Span span;
+        private boolean finishOnDeactivate;
+        private MDCContinuation toRestore = null;
+
+        MDCContinuation(Span span) {
+>>>>>>> Stashed changes
             this.mdcContext = MDC.getCopyOfContextMap();
             this.span = span;
         }
@@ -57,6 +69,7 @@ public class MDCScheduler implements Scheduler {
     }
 
     @Override
+<<<<<<< Updated upstream
     public MDCSnapshot captureActive() {
         return new MDCSnapshot(active());
     }
@@ -64,11 +77,24 @@ public class MDCScheduler implements Scheduler {
     @Override
     public MDCSnapshot capture(Span span) {
         return new MDCSnapshot(span);
+=======
+    public MDCContinuation captureActive() {
+        return new MDCContinuation(active());
+    }
+
+    @Override
+    public MDCContinuation capture(Span span) {
+        return new MDCContinuation(span);
+>>>>>>> Stashed changes
     }
 
     @Override
     public Span active() {
+<<<<<<< Updated upstream
         MDCSnapshot snapshot = tlsSnapshot.get();
+=======
+        MDCContinuation snapshot = tlsSnapshot.get();
+>>>>>>> Stashed changes
         if (snapshot == null) {
             return null;
         }

--- a/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/MDCSpanScheduler.java
+++ b/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/MDCSpanScheduler.java
@@ -1,0 +1,84 @@
+package io.opentracing.mdcdemo;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.SpanScheduler;
+import org.slf4j.MDC;
+
+import java.util.Map;
+
+/**
+ * MDCSpanScheduler illustrates the core SpanScheduler concepts and capabilities to a first approximation. Not
+ * production-quality code.
+ */
+public class MDCSpanScheduler implements SpanScheduler {
+    private final ThreadLocal<MDCSnapshot> tlsSnapshot = new ThreadLocal<MDCSnapshot>();
+
+    class MDCSnapshot implements Continuation {
+        private final Map<String, String> mdcContext;
+        private final Span span;
+        private boolean finishOnDeactivate;
+        private MDCSnapshot toRestore = null;
+
+        MDCSnapshot(Span span) {
+            this.mdcContext = MDC.getCopyOfContextMap();
+            this.span = span;
+        }
+
+        @Override
+        public Span activate(boolean finishOnDeactivate) {
+            this.finishOnDeactivate = finishOnDeactivate;
+            toRestore = tlsSnapshot.get();
+            tlsSnapshot.set(this);
+            return span;
+        }
+
+        @Override
+        public void close() {
+            this.doDeactivate(this.finishOnDeactivate);
+        }
+
+        @Override
+        public void deactivate() {
+            doDeactivate(this.finishOnDeactivate);
+        }
+
+        private void doDeactivate(boolean finishSpan) {
+            if (span != null && finishSpan) {
+                span.finish();
+            }
+
+            if (tlsSnapshot.get() != this) {
+                // This shouldn't happen if users call methods in the expected order. Bail out.
+                return;
+            }
+            tlsSnapshot.set(toRestore);
+        }
+    }
+
+    @Override
+    public MDCSnapshot captureActive() {
+        return new MDCSnapshot(active());
+    }
+
+    @Override
+    public MDCSnapshot capture(Span span) {
+        return new MDCSnapshot(span);
+    }
+
+    @Override
+    public Span active() {
+        MDCSnapshot snapshot = tlsSnapshot.get();
+        if (snapshot == null) {
+            return null;
+        }
+        return snapshot.span;
+    }
+
+    @Override
+    public SpanContext activeContext() {
+        Span active = this.active();
+        if (active == null) return null;
+        return active.context();
+    }
+}

--- a/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/TracedCallable.java
+++ b/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/TracedCallable.java
@@ -22,7 +22,12 @@ public class TracedCallable<T> implements Callable<T> {
     }
 
     public T call() throws Exception {
+<<<<<<< Updated upstream
         final Span span = continuation.activate(true);
+=======
+        // NOTE: There's no way to be sure about the finishOnDeactivate parameter to activate(), so we play it safe.
+        final Span span = continuation.activate(false);
+>>>>>>> Stashed changes
         try {
             return callable.call();
         } finally {

--- a/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/TracedCallable.java
+++ b/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/TracedCallable.java
@@ -1,20 +1,20 @@
 package io.opentracing.mdcdemo;
 
-import io.opentracing.SpanScheduler;
+import io.opentracing.Scheduler;
 import io.opentracing.Span;
 
 import java.util.concurrent.Callable;
 
 public class TracedCallable<T> implements Callable<T> {
-    private SpanScheduler.Continuation continuation;
-    private SpanScheduler scheduler;
+    private Scheduler.Continuation continuation;
+    private Scheduler scheduler;
     private Callable<T> callable;
 
-    public TracedCallable(Callable<T> callable, SpanScheduler scheduler) {
+    public TracedCallable(Callable<T> callable, Scheduler scheduler) {
         this(callable, scheduler.active(), scheduler);
     }
 
-    public TracedCallable(Callable<T> callable, Span span, SpanScheduler scheduler) {
+    public TracedCallable(Callable<T> callable, Span span, Scheduler scheduler) {
         if (callable == null) throw new NullPointerException("Callable is <null>.");
         this.callable = callable;
         this.scheduler = scheduler;

--- a/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/TracedCallable.java
+++ b/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/TracedCallable.java
@@ -1,0 +1,32 @@
+package io.opentracing.mdcdemo;
+
+import io.opentracing.SpanScheduler;
+import io.opentracing.Span;
+
+import java.util.concurrent.Callable;
+
+public class TracedCallable<T> implements Callable<T> {
+    private SpanScheduler.Continuation continuation;
+    private SpanScheduler scheduler;
+    private Callable<T> callable;
+
+    public TracedCallable(Callable<T> callable, SpanScheduler scheduler) {
+        this(callable, scheduler.active(), scheduler);
+    }
+
+    public TracedCallable(Callable<T> callable, Span span, SpanScheduler scheduler) {
+        if (callable == null) throw new NullPointerException("Callable is <null>.");
+        this.callable = callable;
+        this.scheduler = scheduler;
+        this.continuation = scheduler.captureActive();
+    }
+
+    public T call() throws Exception {
+        final Span span = continuation.activate(true);
+        try {
+            return callable.call();
+        } finally {
+            continuation.deactivate();
+        }
+    }
+}

--- a/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/TracedExecutorService.java
+++ b/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/TracedExecutorService.java
@@ -1,7 +1,6 @@
 package io.opentracing.mdcdemo;
 
-import io.opentracing.SpanScheduler;
-import io.opentracing.ThreadLocalScheduler;
+import io.opentracing.Scheduler;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -10,11 +9,11 @@ import java.util.concurrent.*;
 
 public class TracedExecutorService implements ExecutorService {
     private ExecutorService executor;
-    private SpanScheduler scheduler;
+    private Scheduler scheduler;
 
-    public TracedExecutorService(ExecutorService executor, SpanScheduler scheduler) {
+    public TracedExecutorService(ExecutorService executor, Scheduler scheduler) {
         if (executor == null) throw new NullPointerException("Executor is <null>.");
-        if (scheduler == null) throw new NullPointerException("SpanScheduler is <null>.");
+        if (scheduler == null) throw new NullPointerException("Scheduler is <null>.");
         this.executor = executor;
         this.scheduler = scheduler;
     }

--- a/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/TracedExecutorService.java
+++ b/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/TracedExecutorService.java
@@ -1,0 +1,96 @@
+package io.opentracing.mdcdemo;
+
+import io.opentracing.SpanScheduler;
+import io.opentracing.ThreadLocalScheduler;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.*;
+
+public class TracedExecutorService implements ExecutorService {
+    private ExecutorService executor;
+    private SpanScheduler scheduler;
+
+    public TracedExecutorService(ExecutorService executor, SpanScheduler scheduler) {
+        if (executor == null) throw new NullPointerException("Executor is <null>.");
+        if (scheduler == null) throw new NullPointerException("SpanScheduler is <null>.");
+        this.executor = executor;
+        this.scheduler = scheduler;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        executor.execute(new TracedRunnable(command, scheduler));
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return executor.submit(new TracedRunnable(task, scheduler));
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return executor.submit(new TracedRunnable(task, scheduler), result);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return executor.submit(new TracedCallable(task, scheduler));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return executor.invokeAll(tasksWithTracing(tasks));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+        throws InterruptedException {
+        return executor.invokeAll(tasksWithTracing(tasks), timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return executor.invokeAny(tasksWithTracing(tasks));
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+        throws InterruptedException, ExecutionException, TimeoutException {
+        return executor.invokeAny(tasksWithTracing(tasks), timeout, unit);
+    }
+
+    @Override
+    public void shutdown() {
+        executor.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return executor.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return executor.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return executor.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return executor.awaitTermination(timeout, unit);
+    }
+
+    private <T> Collection<? extends Callable<T>> tasksWithTracing(
+        Collection<? extends Callable<T>> tasks) {
+        if (tasks == null) throw new NullPointerException("Collection of tasks is <null>.");
+        Collection<Callable<T>> result = new ArrayList<Callable<T>>(tasks.size());
+        for (Callable<T> task : tasks) result.add(new TracedCallable(task, scheduler));
+        return result;
+    }
+}

--- a/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/TracedRunnable.java
+++ b/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/TracedRunnable.java
@@ -1,0 +1,33 @@
+package io.opentracing.mdcdemo;
+
+import io.opentracing.SpanScheduler;
+import io.opentracing.Span;
+
+
+public class TracedRunnable implements Runnable {
+    private Runnable runnable;
+    private SpanScheduler manschedulerer;
+    private SpanScheduler.Continuation continuation;
+
+    public TracedRunnable(Runnable runnable, SpanScheduler manschedulerer) {
+        this(runnable, manschedulerer.active(), manschedulerer);
+    }
+
+    public TracedRunnable(Runnable runnable, Span span, SpanScheduler manschedulerer) {
+        if (runnable == null) throw new NullPointerException("Runnable is <null>.");
+        this.runnable = runnable;
+        this.manschedulerer = manschedulerer;
+        this.continuation = manschedulerer.captureActive();
+    }
+
+    @Override
+    public void run() {
+        // XXX: There's no good way to know what the activate() param should be here.
+        final Span span = this.continuation.activate(true);
+        try {
+            runnable.run();
+        } finally {
+            this.continuation.deactivate();
+        }
+    }
+}

--- a/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/TracedRunnable.java
+++ b/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/TracedRunnable.java
@@ -1,19 +1,19 @@
 package io.opentracing.mdcdemo;
 
-import io.opentracing.SpanScheduler;
+import io.opentracing.Scheduler;
 import io.opentracing.Span;
 
 
 public class TracedRunnable implements Runnable {
     private Runnable runnable;
-    private SpanScheduler schedulerer;
-    private SpanScheduler.Continuation continuation;
+    private Scheduler schedulerer;
+    private Scheduler.Continuation continuation;
 
-    public TracedRunnable(Runnable runnable, SpanScheduler schedulerer) {
+    public TracedRunnable(Runnable runnable, Scheduler schedulerer) {
         this(runnable, schedulerer.active(), schedulerer);
     }
 
-    public TracedRunnable(Runnable runnable, Span span, SpanScheduler schedulerer) {
+    public TracedRunnable(Runnable runnable, Span span, Scheduler schedulerer) {
         if (runnable == null) throw new NullPointerException("Runnable is <null>.");
         this.runnable = runnable;
         this.schedulerer = schedulerer;

--- a/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/TracedRunnable.java
+++ b/opentracing-mdc-demo/src/main/java/io/opentracing/mdcdemo/TracedRunnable.java
@@ -6,24 +6,24 @@ import io.opentracing.Span;
 
 public class TracedRunnable implements Runnable {
     private Runnable runnable;
-    private SpanScheduler manschedulerer;
+    private SpanScheduler schedulerer;
     private SpanScheduler.Continuation continuation;
 
-    public TracedRunnable(Runnable runnable, SpanScheduler manschedulerer) {
-        this(runnable, manschedulerer.active(), manschedulerer);
+    public TracedRunnable(Runnable runnable, SpanScheduler schedulerer) {
+        this(runnable, schedulerer.active(), schedulerer);
     }
 
-    public TracedRunnable(Runnable runnable, Span span, SpanScheduler manschedulerer) {
+    public TracedRunnable(Runnable runnable, Span span, SpanScheduler schedulerer) {
         if (runnable == null) throw new NullPointerException("Runnable is <null>.");
         this.runnable = runnable;
-        this.manschedulerer = manschedulerer;
-        this.continuation = manschedulerer.captureActive();
+        this.schedulerer = schedulerer;
+        this.continuation = schedulerer.captureActive();
     }
 
     @Override
     public void run() {
-        // XXX: There's no good way to know what the activate() param should be here.
-        final Span span = this.continuation.activate(true);
+        // NOTE: There's no way to be sure about the finishOnDeactivate parameter to activate(), so we play it safe.
+        final Span span = this.continuation.activate(false);
         try {
             runnable.run();
         } finally {

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,14 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This shows how one might build off of https://github.com/opentracing/opentracing-java/pull/111

What's here couples MDC to the `io.opentracing.Scheduler` interface and illustrates usage with a very simple demo mainline.